### PR TITLE
[Matrix] fix seek problems 

### DIFF
--- a/vfs.rar/addon.xml.in
+++ b/vfs.rar/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="vfs.rar"
-  version="3.1.3"
+  version="3.1.4"
   name="RAR archive support"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Fix seek problems about encrypted packages and hopefully also for other cases

There are some changes:
- Add some log calls to see what happens on seek error
- Fix seek of enrypted packages where now the correct place becomes set
- Possibly, other seek problems have also been fixed
- Change some calls to do direct and without function

Not 100% sure that the problem is really fixed and need test from others.

But with this becomes the issue https://github.com/xbmc/vfs.rar/issues/64 closed.