### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This is a [Kodi](https://kodi.tv) VFS addon to extract RAR archives or direct playback stored files in RAR archives.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build and run tests](https://github.com/xbmc/vfs.rar/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/xbmc/vfs.rar/actions/workflows/build.yml)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.vfs.rar?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=52&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/vfs.rar/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvfs.rar/branches/)
+[![Build and run tests](https://github.com/xbmc/vfs.rar/actions/workflows/build.yml/badge.svg?branch=Nexus)](https://github.com/xbmc/vfs.rar/actions/workflows/build.yml)
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.vfs.rar?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=52&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/vfs.rar/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvfs.rar/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/vfs.rar?svg=true)](https://ci.appveyor.com/project/xbmc/vfs-rar) -->
 
 ## Build instructions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   branches:
     include:
     - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/vfs.rar/addon.xml.in
+++ b/vfs.rar/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="vfs.rar"
-  version="4.0.0"
+  version="20.0.0"
   name="RAR archive support"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.