### PR TITLE
Adds setting "Unpack compressed"

### DIFF
--- a/src/RarFile.cpp
+++ b/src/RarFile.cpp
@@ -66,6 +66,12 @@ kodi::addon::VFSFileHandle CRARFile::Open(const kodi::addon::VFSUrl& url)
   }
   else
   {
+    if (!CRarManager::Get().m_unpackCompressed)
+    {
+      delete result;
+      return nullptr;
+    }
+
     CFileInfo* info = CRarManager::Get().GetFileInRar(result->GetPath(), result->m_pathinrar);
     if ((!info || !kodi::vfs::FileExists(info->m_strCachedPath, true)) && result->m_fileoptions & EXFILE_NOCACHE)
     {

--- a/src/RarManager.cpp
+++ b/src/RarManager.cpp
@@ -54,6 +54,7 @@ CRarManager& CRarManager::Get()
 CRarManager::CRarManager()
 {
   // Load the current settings and store to reduce call amount of them
+  m_unpackCompressed = kodi::addon::GetSettingBoolean("unpack_compressed");
   m_asksToUnpack = kodi::addon::GetSettingBoolean("asks_to_unpack");
   m_passwordAskAllowed = kodi::addon::GetSettingBoolean("usercheck_for_password");
   for (unsigned int i = 0; i < MAX_STANDARD_PASSWORDS; ++i)
@@ -71,6 +72,8 @@ void CRarManager::SettingsUpdate(const std::string& settingName, const kodi::add
   // addon settings by e.g. user.
   if (settingName == "asks_to_unpack")
     m_asksToUnpack = settingValue.GetBoolean();
+  else if (settingName == "unpack_compressed")
+    m_unpackCompressed = settingValue.GetBoolean();
   else if (settingName == "usercheck_for_password")
     m_passwordAskAllowed = settingValue.GetBoolean();
   else if (settingName == "standard_password_1")

--- a/src/RarManager.h
+++ b/src/RarManager.h
@@ -71,6 +71,7 @@ private:
   std::map<std::string, std::pair<std::vector<RARHeaderDataEx>,std::vector<CFileInfo> > > m_ExFiles;
   std::recursive_mutex m_lock;
 
+  bool m_unpackCompressed = true;
   bool m_asksToUnpack = true;
   bool m_passwordAskAllowed = false;
   std::string m_standardPasswords[MAX_STANDARD_PASSWORDS];

--- a/vfs.rar/resources/language/resource.language.en_gb/strings.po
+++ b/vfs.rar/resources/language/resource.language.en_gb/strings.po
@@ -113,3 +113,11 @@ msgstr ""
 msgctxt "#30024"
 msgid "Asks you with a dialog to confirm the unpacking of a larger file."
 msgstr ""
+
+msgctxt "#30025"
+msgid "Unpack compressed"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Disable to avoid unpacking compressed rar archives."
+msgstr ""

--- a/vfs.rar/resources/settings.xml
+++ b/vfs.rar/resources/settings.xml
@@ -3,6 +3,10 @@
   <section id="vfs.rar">
     <category id="general" label="30010">
       <group id="1">
+        <setting id="unpack_compressed" type="boolean" label="30025" help="30026">
+          <default>true</default>
+          <control type="toggle"/>
+        </setting>
         <setting id="asks_to_unpack" type="boolean" label="30023" help="30024">
           <default>true</default>
           <control type="toggle"/>


### PR DESCRIPTION
If it is set to false, then no compressed archives are unpacked and the addon only deals with non-compressed rar archives (method "Store").

**What I'm trying to solve**  
Me and many other have experienced issues using Kodi with rar'ed movies since Kodi v18 or v19. One example is issue #102 which describes experiences similar to mine. It seems to work, but it can't be used because it is unpacking compressed archives and keep asking about the same files every library scan.

**How I'm trying to solve it**  
I've added a setting to enable unpacking of compressed files. It is on by default, to not change the current behaviour. To solve the issues caused by unpacking compressed files one disables the setting. 

I'm new to Kodi development and C++. If my edits aren't working the way I intended I'd be very happy to get some advice.

