### PR TITLE
Fixes build error #174

### DIFF
--- a/src/RarFile.cpp
+++ b/src/RarFile.cpp
@@ -66,7 +66,7 @@ kodi::addon::VFSFileHandle CRARFile::Open(const kodi::addon::VFSUrl& url)
   }
   else
   {
-    if (!CRarManager::Get().m_unpackCompressed)
+    if (!CRarManager::Get().UnpackCompressed())
     {
       delete result;
       return nullptr;

--- a/src/RarManager.h
+++ b/src/RarManager.h
@@ -60,6 +60,7 @@ public:
   void ExtractArchive(const std::string& strArchive, const std::string& strPath);
 
   void SettingsUpdate(const std::string& settingName, const kodi::addon::CSettingValue& settingValue);
+  bool UnpackCompressed() const { return m_unpackCompressed; }
   bool PasswordAskAllowed() const { return m_passwordAskAllowed; }
   const std::string& StandardPassword(int no) { return m_standardPasswords[no]; }
 


### PR DESCRIPTION
Fixes build error #174, introduced in #167 (by me, sorry!)

Using a public accessor instead of private member for UnpackCompressed.

I currently do not have the ability to build this project locally. Apologies for the inconvenience.