### PR TITLE
vfs.rar: fix RAR handle cleanup on close paths

### DIFF
--- a/src/RarControl.cpp
+++ b/src/RarControl.cpp
@@ -307,6 +307,7 @@ int CRARControl::ArchiveExtract(const std::string& targetPath, const std::string
 
       RarErrorLog(__func__, result);
       retValue = 0;
+      RARCloseArchive(archive);
       continue;
     }
     else if ((needPassword && currentPw != m_password) || m_passwordSeemsBad)
@@ -518,6 +519,7 @@ RARContext::RARContext(const kodi::addon::VFSUrl& url)
 
 RARContext::~RARContext()
 {
+  CleanUp();
   if (m_file)
     delete m_file;
   delete m_buffer;
@@ -740,18 +742,28 @@ void RARContext::CleanUp()
   {
     if (m_extract_thread)
     {
-      if (m_extract_thread->hRunning.Wait(1))
-      {
-        m_extract.GetDataIO().hQuit->Broadcast();
-        while (m_extract_thread->hRunning.Wait(1))
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      }
+      m_extract.GetDataIO().hQuit->Broadcast();
+      while (m_extract_thread->hRunning.Wait(1))
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
       delete m_extract.GetDataIO().hBufferFilled;
+      m_extract.GetDataIO().hBufferFilled = nullptr;
       delete m_extract.GetDataIO().hBufferEmpty;
+      m_extract.GetDataIO().hBufferEmpty = nullptr;
       delete m_extract.GetDataIO().hSeek;
+      m_extract.GetDataIO().hSeek = nullptr;
       delete m_extract.GetDataIO().hSeekDone;
+      m_extract.GetDataIO().hSeekDone = nullptr;
       delete m_extract.GetDataIO().hQuit;
+      m_extract.GetDataIO().hQuit = nullptr;
+
+      delete m_extract_thread;
+      m_extract_thread = nullptr;
     }
+
+    // Ensure archive descriptors are released immediately on Close().
+    if (m_arc.IsOpened())
+      m_arc.Close();
   }
   catch (int rarErrCode)
   {


### PR DESCRIPTION
## Problem

When playing files from multi-part RAR archives over SMB (`rar://smb://...`), file handles can remain open after playback stop/close.
This can prevent immediate deletion of archive files/folders on the server side.

This appears to be the same class of issue described in:
- https://github.com/xbmc/vfs.rar/issues/159
- https://github.com/xbmc/vfs.rar/issues/98

## Root cause

Archive/context cleanup was not guaranteed in all relevant close/error lifecycle paths, so descriptors could stay open longer than intended.

## Changes

- `src/RarControl.cpp`

1. `CRARControl::ArchiveExtract(...)`
   - Ensure `RARCloseArchive(archive)` is called before `continue` in the error path.

2. `RARContext::~RARContext()`
   - Call `CleanUp()` from destructor to guarantee teardown on destruction.

3. `RARContext::CleanUp()`
   - Always broadcast `hQuit` and wait for extract thread shutdown.
   - Delete DataIO event handles and set their pointers to `nullptr`.
   - Delete `m_extract_thread` and set pointer to `nullptr`.
   - Explicitly close archive via `m_arc.Close()` if still opened.

## Verification

Reproduced with SMB-hosted multi-part RAR content:
1. Start playback from `rar://smb://...`
2. Stop/close playback
3. Check server-side open handles

Before:
- lingering handles on `.rar` / `.rNN`
- deletion errors

After:
- no lingering matching handles after close (checked via `smbstatus`/`lsof`)
- no delete error observed for the tested scenario

## Risk

Low. Changes are limited to cleanup/teardown paths and do not alter normal archive read/extract logic.
