### PR TITLE
[RarFile] Prevent extraction of entire archive when file does not exist.

### DIFF
--- a/src/RarFile.cpp
+++ b/src/RarFile.cpp
@@ -36,8 +36,15 @@ kodi::addon::VFSFileHandle CRARFile::Open(const kodi::addon::VFSUrl& url)
   RARContext* result = new RARContext(url);
 
   kodi::vfs::CDirEntry item;
-  if (CRarManager::Get().GetFileInRar(result->GetPath(), result->m_pathinrar, item) &&
-      item.GetProperties().size() == 1 && std::stoi(item.GetProperties().begin()->second) == 0x30)
+  if (!CRarManager::Get().GetFileInRar(result->GetPath(), result->m_pathinrar, item))
+  {
+    // Not an actual file inside the archive (e.g. the archive root itself, as
+    // probed by CFile::Stat()/Exists() before a directory listing).
+    delete result;
+    return nullptr;
+  }
+
+  if (item.GetProperties().size() == 1 && std::stoi(item.GetProperties().begin()->second) == 0x30)
   {
     if (!result->OpenInArchive())
     {


### PR DESCRIPTION
`CDirectoryFactory::Create()` in Kodi core calls `CFile::Stat()` on every URL (including the archive root) before choosing an IDirectory.

That reaches `CRARFile::Stat() → Open()` with an empty m_pathinrar. The old code didn't check whether `GetFileInRar()` actually found a matching entry — it fell through to the "must be compressed, cache-extract it" branch regardless, and since the path was empty.

`ArchiveExtract's fileToExtract.empty()` check set `all = true`, extracting the entire archive (all files) just to answer a stat/exists probe.

The fix makes `Open()` fail fast when the requested path isn't a real file in the archive, so `Stat()` correctly falls through to its cheap DirectoryExists()/ArchiveList-based check instead.

Fix #187 